### PR TITLE
Add macOS dark mode support

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,8 @@
   --foreground: #222;
   --primary: #ff4a00;
   --page-max-width: 1300px;
+  --footer-background: #ececec70;
+  --footer-border-color: #fff;
 }
 
 @theme inline {
@@ -33,6 +35,7 @@
 html {
   font-size: 14px;
   line-height: 130%;
+  color-scheme: light dark;
 }
 
 body {
@@ -52,4 +55,26 @@ body {
 svg {
   display: block;
   flex-shrink: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #1e1e1e;
+    --foreground: #e5e5e5;
+    --color-screen: #000000;
+    --color-black-10: rgba(255, 255, 255, 0.1);
+    --color-black-50: rgba(255, 255, 255, 0.5);
+    --footer-background: #00000070;
+    --footer-border-color: #333;
+  }
+
+  body {
+    @variant sm {
+      background-image: linear-gradient(
+        to bottom right,
+        #000000,
+        var(--background) 20%
+      );
+    }
+  }
 }

--- a/src/components/ui/Footer.module.css
+++ b/src/components/ui/Footer.module.css
@@ -5,7 +5,7 @@
   left: 0;
   z-index: 20;
   border-top: 1px solid transparent;
-  background: #ececec70;
+  background: var(--footer-background);
   backdrop-filter: blur(2rem);
   -webkit-backdrop-filter: blur(2rem);
   font-size: 1.125rem;
@@ -13,7 +13,7 @@
 }
 
 [data-scrollable="true"] .Footer {
-  border-top: 1px solid #fff;
+  border-top: 1px solid var(--footer-border-color);
 }
 
 @keyframes wave {


### PR DESCRIPTION
## Summary
- use CSS variables for footer styles
- add dark mode color variables and media query

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_i_6838ef8ea578832ab9894327728cde54